### PR TITLE
fix: joinSteps function when step is empty

### DIFF
--- a/src/epubcfi.js
+++ b/src/epubcfi.js
@@ -239,6 +239,10 @@ EpubCFI.prototype.getCharecterOffsetComponent = function(cfiStr) {
 };
 
 EpubCFI.prototype.joinSteps = function(steps) {
+  if(!steps) {
+    return "";
+  }
+
   return steps.map(function(part){
     var segment = '';
 


### PR DESCRIPTION
This fix prevents toString function to fail